### PR TITLE
use symbol versioning

### DIFF
--- a/gusb/Makefile.am
+++ b/gusb/Makefile.am
@@ -45,7 +45,7 @@ libgusb_la_LDFLAGS =						\
 	-version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE)	\
 	-export-dynamic						\
 	-no-undefined						\
-	-export-symbols-regex '^g_usb_.*'
+	-Wl,--version-script=$(top_srcdir)/gusb/libgusb.ver
 
 libgusb_la_CFLAGS =						\
 	$(WARNINGFLAGS_C)

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -1,0 +1,36 @@
+LIBGUSB_0.1.0 {
+  global:
+    g_usb_*;
+  local: *;
+};
+
+LIBGUSB_0.1.1 {
+  global:
+    g_usb_device_get_platform_id;
+} LIBGUSB_0.1.0;
+
+LIBGUSB_0.1.7 {
+  global:
+    g_usb_device_get_device_class;
+} LIBGUSB_0.1.1;
+
+LIBGUSB_0.2.2 {
+  global:
+    g_usb_context_enumerate;
+    g_usb_context_find_by_bus_address;
+    g_usb_context_find_by_vid_pid;
+    g_usb_context_get_devices;
+} LIBGUSB_0.1.7;
+
+LIBGUSB_0.2.4 {
+  global:
+    g_usb_device_get_parent;
+    g_usb_device_get_children;
+    g_usb_device_get_port_number;
+    g_usb_device_get_vid_as_str;
+    g_usb_device_get_pid_as_str;
+    g_usb_device_get_device_subclass;
+    g_usb_device_get_device_protocol;
+    g_usb_context_find_by_platform_id;
+} LIBGUSB_0.2.2;
+


### PR DESCRIPTION
I started the map based on the 'auto export filter' (g_usb_*, marking those as 'LIBGUSB_0.1.0' and the rest * as local.

Then I parsed the .c files finding all functions that had a 'Since: ' tag, adding them to the respective version block (with correct inheritance)

Seeing that libgusb is rather new, this is still a doable effort. It would avoid cases as were discussed today where a user updates one package, but not the lib to it: with versioned symbols, RPM would have told this lib is needed (and higher level PMs, like PackageKit, would have triggered the lib for an  update).