### PR TITLE
Add missing element-type annotations.

### DIFF
--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -918,7 +918,7 @@ _g_usb_context_lookup_product (GUsbContext  *context,
  * g_usb_context_get_devices:
  * @context: a #GUsbContext
  *
- * Return value: (transfer full): a new #GPtrArray of #GUsbDevice's.
+ * Return value: (transfer full) (element-type GUsbDevice): a new #GPtrArray of #GUsbDevice's.
  *
  * Since: 0.2.2
  **/

--- a/gusb/gusb-device-list.c
+++ b/gusb/gusb-device-list.c
@@ -181,7 +181,7 @@ g_usb_device_list_init (GUsbDeviceList *list)
  * g_usb_device_list_get_devices:
  * @list: a #GUsbDeviceList
  *
- * Return value: (transfer full): a new #GPtrArray of #GUsbDevice's.
+ * Return value: (transfer full) (element-type GUsbDevice): a new #GPtrArray of #GUsbDevice's.
  *
  * Since: 0.1.0
  **/

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -1433,7 +1433,7 @@ g_usb_device_get_parent (GUsbDevice *device)
  *
  * Gets the device children if any exist.
  *
- * Return value: (transfer full): an array of #GUsbDevice
+ * Return value: (transfer full) (element-type GUsbDevice): an array of #GUsbDevice
  *
  * Since: 0.2.4
  **/


### PR DESCRIPTION
This allows g_usb_context_get_devices, usb_device_list_get_devices and
g_usb_device_get_children to be used in languages that use gobject
introspection like Vala, Python etc.