### PR TITLE
Fix gtk-doc build when builddir != srcdir

### DIFF
--- a/docs/api/Makefile.am
+++ b/docs/api/Makefile.am
@@ -14,7 +14,7 @@ DOC_MAIN_SGML_FILE=$(DOC_MODULE)-docs.sgml
 # The directory containing the source code. Relative to $(srcdir).
 # gtk-doc will search all .c & .h files beneath here for inline comments
 # documenting the functions and macros.
-DOC_SOURCE_DIR=../../gusb
+DOC_SOURCE_DIR=$(top_srcdir)/gusb $(top_builddir)/gusb
 
 # Extra options to pass to gtkdoc-scangobj. Not normally needed.
 SCANGOBJ_OPTIONS=


### PR DESCRIPTION
This fixes the following error;

```
warning: failed to load external entity "../xml/gusb-context.xml"
../gusb-docs.sgml:49: element include: XInclude error : could not load ../xml/gusb-context.xml, and no fallback was found
warning: failed to load external entity "../xml/gusb-source.xml"
../gusb-docs.sgml:50: element include: XInclude error : could not load ../xml/gusb-source.xml, and no fallback was found
warning: failed to load external entity "../xml/gusb-device.xml"
../gusb-docs.sgml:51: element include: XInclude error : could not load ../xml/gusb-device.xml, and no fallback was found
warning: failed to load external entity "../xml/gusb-device-list.xml"
../gusb-docs.sgml:52: element include: XInclude error : could not load ../xml/gusb-device-list.xml, and no fallback was found
warning: failed to load external entity "../xml/gusb-interface.xml"
../gusb-docs.sgml:53: element include: XInclude error : could not load ../xml/gusb-interface.xml, and no fallback was found
```