### PR TITLE
Port to FreeBSD

### DIFF
--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -444,6 +444,7 @@ g_usb_context_rescan (GUsbContext *context)
 	libusb_free_device_list (dev_list, 1);
 }
 
+#ifndef __FreeBSD__
 static gboolean
 g_usb_context_rescan_cb (gpointer user_data)
 {
@@ -451,6 +452,7 @@ g_usb_context_rescan_cb (gpointer user_data)
 	g_usb_context_rescan (context);
 	return TRUE;
 }
+#endif
 
 
 /**
@@ -516,12 +518,14 @@ g_usb_context_enumerate (GUsbContext *context)
 		return;
 
 	g_usb_context_rescan (context);
+#ifndef __FreeBSD__
 	if (!libusb_has_capability (LIBUSB_CAP_HAS_HOTPLUG)) {
 		g_debug ("platform does not do hotplug, using polling");
 		priv->hotplug_poll_id = g_timeout_add_seconds (1,
 							       g_usb_context_rescan_cb,
 							       context);
 	}
+#endif
 	priv->done_enumerate = TRUE;
 }
 
@@ -616,7 +620,9 @@ g_usb_context_initable_init (GInitable     *initable,
 					   context);
 
 	/* watch for add/remove */
+#ifndef __FreeBSD__
 	if (libusb_has_capability (LIBUSB_CAP_HAS_HOTPLUG)) {
+#endif
 		rc = libusb_hotplug_register_callback (priv->ctx,
 						       LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED |
 						       LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT,
@@ -631,7 +637,9 @@ g_usb_context_initable_init (GInitable     *initable,
 			g_warning ("Error creating a hotplug callback: %s",
 				   g_usb_strerror (rc));
 		}
+#ifndef __FreeBSD__
 	}
+#endif
 
 	return TRUE;
 }

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -38,6 +38,7 @@ struct _GUsbDevicePrivate
 	GUsbContext		*context;
 	libusb_device		*device;
 	libusb_device_handle	*handle;
+	GArray                  *port_numbers;
 	struct libusb_device_descriptor desc;
 };
 
@@ -84,6 +85,7 @@ g_usb_device_dispose (GObject *object)
 	GUsbDevice *device = G_USB_DEVICE (object);
 	GUsbDevicePrivate *priv = device->priv;
 
+	g_clear_pointer (&priv->port_numbers, g_array_unref);
 	g_clear_pointer (&priv->device, libusb_unref_device);
 	g_clear_object (&priv->context);
 
@@ -202,25 +204,20 @@ g_usb_device_init (GUsbDevice *device)
 	device->priv = g_usb_device_get_instance_private (device);
 }
 
-static void
-g_usb_device_build_parent_port_number (GString *str, libusb_device *dev)
-{
-	libusb_device *parent = libusb_get_parent (dev);
-	if (parent != NULL)
-		g_usb_device_build_parent_port_number (str, parent);
-	g_string_append_printf (str, "%02x:", libusb_get_port_number (dev));
-}
-
 static gchar *
-g_usb_device_build_platform_id (struct libusb_device *dev)
+g_usb_device_build_platform_id (GUsbDevice *device)
 {
+	GUsbDevicePrivate *priv = device->priv;
 	GString *platform_id;
+	guint i;
 
 	/* build a topology of the device */
-	platform_id = g_string_new ("usb:");
-	g_string_append_printf (platform_id, "%02x:", libusb_get_bus_number (dev));
-	g_usb_device_build_parent_port_number (platform_id, dev);
-	g_string_truncate (platform_id, platform_id->len - 1);
+	platform_id = g_string_new ("usb");
+	g_string_append_printf (platform_id, ":%02x",
+				libusb_get_bus_number (priv->device));
+	for (i = 0; i < priv->port_numbers->len; i++)
+		g_string_append_printf (platform_id, ":%02x",
+					g_array_index (priv->port_numbers, guint8, i));
 	return g_string_free (platform_id, FALSE);
 }
 
@@ -251,8 +248,32 @@ g_usb_device_initable_init (GInitable     *initable,
 		return FALSE;
 	}
 
+	/* Store port number values to ease parent device finding on FreeBSD.
+	 * FreeBSD's libusb requires a device to be opened before calling
+	 * libusb_get_port_numbers because it needs the fd to call ioctl. */
+#define PORT_NUMBER_MAX 64
+	priv->port_numbers = g_array_new (FALSE, FALSE, sizeof (guint8));
+#ifdef __FreeBSD__
+	g_return_val_if_fail (priv->handle == NULL, FALSE);
+	if (libusb_open (priv->device, &priv->handle) == LIBUSB_SUCCESS) {
+#endif
+		guint8 ports[PORT_NUMBER_MAX];
+		gint port_count;
+		port_count = libusb_get_port_numbers (priv->device, ports,
+						      PORT_NUMBER_MAX);
+		if (port_count > 0) {
+			g_array_set_size (priv->port_numbers, port_count);
+			memcpy (priv->port_numbers->data, ports, port_count);
+		}
+#ifdef __FreeBSD__
+		libusb_close (priv->handle);
+		priv->handle = NULL;
+	}
+#endif
+#undef PORT_NUMBER_MAX
+
 	/* this does not change on plug->unplug->plug */
-	priv->platform_id = g_usb_device_build_platform_id (priv->device);
+	priv->platform_id = g_usb_device_build_platform_id (device);
 
 	return TRUE;
 }
@@ -1552,6 +1573,41 @@ g_usb_device_get_platform_id (GUsbDevice *device)
 	return device->priv->platform_id;
 }
 
+static libusb_device *
+g_usb_device_get_parent_libusb_device (GUsbDevice *device)
+{
+#ifdef __FreeBSD__
+	GPtrArray *devices = NULL;
+	GUsbDevice *device_tmp;
+	gboolean found = FALSE;
+	guint i;
+
+	if (device->priv->port_numbers->len == 0)
+		return NULL;
+
+	devices = g_usb_context_get_devices (device->priv->context);
+	for (i = 0; devices->len; i++) {
+		device_tmp = g_ptr_array_index (devices, i);
+		if (g_usb_device_get_bus (device) ==
+		    g_usb_device_get_bus (device_tmp) &&
+		    device->priv->port_numbers->len - 1 ==
+		    device_tmp->priv->port_numbers->len &&
+		    memcmp (device->priv->port_numbers->data,
+			    device_tmp->priv->port_numbers->data,
+			    device_tmp->priv->port_numbers->len) == 0) {
+			found = TRUE;
+			break;
+		}
+	}
+
+	g_ptr_array_unref (devices);
+
+	return found ? device_tmp->priv->device : NULL;
+#else
+	return libusb_get_parent (device->priv->device);
+#endif
+}
+
 /**
  * g_usb_device_get_parent:
  * @device: a #GUsbDevice instance
@@ -1568,7 +1624,7 @@ g_usb_device_get_parent (GUsbDevice *device)
 	GUsbDevicePrivate *priv = device->priv;
 	libusb_device *parent;
 
-	parent = libusb_get_parent (priv->device);
+	parent = g_usb_device_get_parent_libusb_device (device);
 	if (parent == NULL)
 		return NULL;
 
@@ -1602,7 +1658,7 @@ g_usb_device_get_children (GUsbDevice *device)
 	devices = g_usb_context_get_devices (priv->context);
 	for (i = 0; i < devices->len; i++) {
 		device_tmp = g_ptr_array_index (devices, i);
-		if (priv->device == libusb_get_parent (device_tmp->priv->device))
+		if (priv->device == g_usb_device_get_parent_libusb_device (device_tmp))
 			g_ptr_array_add (children, g_object_ref (device_tmp));
 	}
 

--- a/gusb/gusb-self-test.c
+++ b/gusb/gusb-self-test.c
@@ -32,8 +32,15 @@ gusb_device_func (void)
 	g_assert_cmpint (array->len, >, 0);
 	device = G_USB_DEVICE (g_ptr_array_index (array, 0));
 
-	g_assert_cmpint (g_usb_device_get_vid (device), >, 0x0000);
-	g_assert_cmpint (g_usb_device_get_pid (device), >, 0x0000);
+	/* Root hubs on FreeBSD have vid and pid set to zero */
+#ifdef __FreeBSD__
+	if (g_usb_device_get_parent (device) != NULL) {
+#endif
+		g_assert_cmpint (g_usb_device_get_vid (device), >, 0x0000);
+		g_assert_cmpint (g_usb_device_get_pid (device), >, 0x0000);
+#ifdef __FreeBSD__
+	}
+#endif
 
 	g_ptr_array_unref (array);
 }
@@ -88,8 +95,14 @@ gusb_context_func (void)
 	for (i = 0; i < array->len; i++) {
 		device = G_USB_DEVICE (g_ptr_array_index (array, i));
 
-		g_assert_cmpint (g_usb_device_get_vid (device), >, 0x0000);
-		g_assert_cmpint (g_usb_device_get_pid (device), >, 0x0000);
+#ifdef __FreeBSD__
+		if (g_usb_device_get_parent (device) != NULL) {
+#endif
+			g_assert_cmpint (g_usb_device_get_vid (device), >, 0x0000);
+			g_assert_cmpint (g_usb_device_get_pid (device), >, 0x0000);
+#ifdef __FreeBSD__
+		}
+#endif
 
 		/* Needed for g_usb_device_get_string_descriptor below,
 		   not error checked to allow running basic tests without

--- a/meson.build
+++ b/meson.build
@@ -93,8 +93,14 @@ add_project_link_arguments(
   language: 'c'
 )
 
+if host_machine.system() == 'freebsd'
+  libusb_version = '>= 1.0.9'
+else
+  libusb_version = '>= 1.0.19'
+endif
+
 libgio = dependency('gio-2.0', version : '>= 2.44.0')
-libusb = dependency('libusb-1.0', version : '>= 1.0.19')
+libusb = dependency('libusb-1.0', version : libusb_version)
 if libusb.version().version_compare ('>= 1.0.22')
   conf.set('HAVE_LIBUSB_1_0_22', '1')
 endif


### PR DESCRIPTION
Since colord made libgusb a hard requirement, I tried to build libgusb in JHBuild on FreeBSD. I found there are only a few missing functions, so I started to port it. These patches enable libgusb to build on FreeBSD and fix a few cross-platform bugs such as wrong platform IDs and broken output in help messages of gusbcmd on non-English locales.

I tested libgusb on FreeBSD with gusbcmd and gusb-self-test. Running `gusbcmd` without arguments hangs because the event handling thread blocks in `libusb_handle_events`, which blocks `g_usb_context_dispose` on `g_thread_join`. `gusbcmd show` works properly because the circular references between GUsbContext and GUsbDevice, so the reference count of GUsbContext never drops to zero and `g_usb_context_dispose` is not called. The details of known problems can be found in the commit message of the last commt 'Root hubs on FreeBSD have vid and pid set to zero'.