### PR TITLE
gusb/meson.build: pass -DGUSB_COMPILATION to gir compiler

### DIFF
--- a/gusb/meson.build
+++ b/gusb/meson.build
@@ -106,6 +106,7 @@ libgusb_girtarget = gnome.generate_gir(gusb,
   export_packages : 'gusb',
   extra_args : [
     '--c-include=gusb.h',
+    '-DGUSB_COMPILATION',
     ],
   link_with : gusb,
   dependencies : [


### PR DESCRIPTION
This fixes cross building of gir using Yocto Project/Buildroot
method.

This is also done on atk with -DATK_COMPILATION and
gdk-pixbuf with -DGDK_PIXBUF_COMPILATION.