### PR TITLE
build: Add -Wswitch-enum

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,6 +59,7 @@ test_args = [
   '-Wstrict-aliasing',
   '-Wstrict-prototypes',
   '-Wswitch-default',
+  '-Wswitch-enum',
   '-Wtype-limits',
   '-Wundef',
   '-Wuninitialized',


### PR DESCRIPTION
This means we still get errors for missing enum values in switches even
in combination with -Wswitch-default and default cases.