### PR TITLE
Fix high number of wakeups when checking the GUsbContext

### DIFF
--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -579,8 +579,8 @@ g_usb_context_event_thread_cb (gpointer data)
 	GUsbContext *context = G_USB_CONTEXT (data);
 	GUsbContextPrivate *priv = context->priv;
 	struct timeval tv = {
-		.tv_sec = 0,
-		.tv_usec = 1000,
+		.tv_usec = 0,
+		.tv_sec = 2,
 	};
 
 	while (g_atomic_int_get (&priv->thread_event_run) > 0)


### PR DESCRIPTION
In 985b9e4ec39ac521e7398a8e3017c96f2c4d75ec I mistakenly thought this was the
timeout for the added/removed context checking, which was Windows-specific.

It actually was the main context event thread, which is running all the time.
Switch the poll timeout to be 2s, (still down from the default 60s!) which is a
better compromise between battery life and context shutdown performance.

Fixes https://github.com/hughsie/libgusb/issues/24