### PR TITLE
generate-version-script: Don't skip methods on plain structs

### DIFF
--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -2,6 +2,7 @@ FROM fedora:31
 
 RUN dnf -y update
 RUN dnf -y install \
+	diffutils \
 	glib2-devel \
 	gobject-introspection-devel \
 	gtk-doc \

--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -50,9 +50,6 @@ class LdVersionScript:
 
         # choose the lowest version method for the _get_type symbol
         version_lowest = None
-        if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
-            return
-        type_name = cls.attrib['{http://www.gtk.org/introspection/glib/1.0}get-type']
 
         # add all class methods
         for node in cls.findall(XMLNS + 'method'):
@@ -67,6 +64,10 @@ class LdVersionScript:
             if version_tmp:
                 if not version_lowest or version_tmp < version_lowest:
                     version_lowest = version_tmp
+
+        if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
+            return
+        type_name = cls.attrib['{http://www.gtk.org/introspection/glib/1.0}get-type']
 
         # finally add the get_type symbol
         if version_lowest:

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -40,6 +40,7 @@ LIBGUSB_0.1.0 {
     g_usb_device_reset;
     g_usb_device_set_configuration;
     g_usb_source_error_quark;
+    g_usb_source_set_callback;
     g_usb_strerror;
   local: *;
 };


### PR DESCRIPTION
This resulted in losing g_usb_source_set_callback@LIBGUSB_0.1.0 from
the ABI in version 0.3.4.

---

Includes #32, please review that first.

I'm trying to work out a way to address #9 and #27 by generating *both* versions - the old, wrong one and the new, correct one - so that a future GUsb will have an ABI that is a superset of every historical version. I haven't got that working yet, but I discovered this bug while trying to get there.