### PR TITLE
Add backwards compatibility with historical ABIs

### DIFF
--- a/contrib/ci/Dockerfile-fedora
+++ b/contrib/ci/Dockerfile-fedora
@@ -2,6 +2,7 @@ FROM fedora:31
 
 RUN dnf -y update
 RUN dnf -y install \
+	diffutils \
 	glib2-devel \
 	gobject-introspection-devel \
 	gtk-doc \

--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -50,9 +50,6 @@ class LdVersionScript:
 
         # choose the lowest version method for the _get_type symbol
         version_lowest = None
-        if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
-            return
-        type_name = cls.attrib['{http://www.gtk.org/introspection/glib/1.0}get-type']
 
         # add all class methods
         for node in cls.findall(XMLNS + 'method'):
@@ -67,6 +64,10 @@ class LdVersionScript:
             if version_tmp:
                 if not version_lowest or version_tmp < version_lowest:
                     version_lowest = version_tmp
+
+        if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
+            return
+        type_name = cls.attrib['{http://www.gtk.org/introspection/glib/1.0}get-type']
 
         # finally add the get_type symbol
         if version_lowest:

--- a/gusb/gusb-abi-compat.h
+++ b/gusb/gusb-abi-compat.h
@@ -1,0 +1,46 @@
+/*<private_header>*/
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright 2020 Simon McVittie
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#ifdef _GUSB_VERSIONED_SYMBOLS
+#define _GUSB_COMPAT_ALIAS(sym, default_ver) \
+  extern __typeof__(sym) _compat_ ## sym __attribute__((alias ("_default_" #sym))); \
+  extern __typeof__(sym) _default_ ## sym; \
+  __asm__(".symver _compat_" #sym "," #sym "@LIBGUSB_0.1.0"); \
+  __asm__(".symver _default_" #sym "," #sym "@@LIBGUSB_" default_ver);
+
+/* These are parsed by generate-version-script.py, do not reformat */
+#define g_usb_context_get_main_context _default_g_usb_context_get_main_context
+#define g_usb_context_set_main_context _default_g_usb_context_set_main_context
+#define g_usb_context_wait_for_replug _default_g_usb_context_wait_for_replug
+#define g_usb_device_get_interface _default_g_usb_device_get_interface
+#define g_usb_device_get_interfaces _default_g_usb_device_get_interfaces
+#define g_usb_device_get_release _default_g_usb_device_get_release
+#define g_usb_device_set_interface_alt _default_g_usb_device_set_interface_alt
+#define g_usb_interface_get_alternate _default_g_usb_interface_get_alternate
+#define g_usb_interface_get_class _default_g_usb_interface_get_class
+#define g_usb_interface_get_extra _default_g_usb_interface_get_extra
+#define g_usb_interface_get_index _default_g_usb_interface_get_index
+#define g_usb_interface_get_kind _default_g_usb_interface_get_kind
+#define g_usb_interface_get_length _default_g_usb_interface_get_length
+#define g_usb_interface_get_number _default_g_usb_interface_get_number
+#define g_usb_interface_get_protocol _default_g_usb_interface_get_protocol
+#define g_usb_interface_get_subclass _default_g_usb_interface_get_subclass
+#define g_usb_interface_get_type _default_g_usb_interface_get_type
+#define g_usb_endpoint_get_number _default_g_usb_endpoint_get_number
+#define g_usb_endpoint_get_refresh _default_g_usb_endpoint_get_refresh
+#define g_usb_endpoint_get_synch_address _default_g_usb_endpoint_get_synch_address
+#define g_usb_endpoint_get_type _default_g_usb_endpoint_get_type
+#define g_usb_version_string _default_g_usb_version_string
+
+#else /* !_GUSB_VERSIONED_SYMBOLS */
+
+#define _GUSB_COMPAT_ALIAS(sym, default_ver) /* nothing */
+
+#endif /* !_GUSB_VERSIONED_SYMBOLS */

--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -17,10 +17,20 @@
 
 #include <libusb.h>
 
+#include "gusb-abi-compat.h"
 #include "gusb-context.h"
 #include "gusb-context-private.h"
 #include "gusb-device-private.h"
 #include "gusb-util.h"
+
+/* New in 0.2.5, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/cfaab3e523c11800b6d77c1d10ce0c71799a4482 */
+_GUSB_COMPAT_ALIAS (g_usb_context_get_main_context, "0.2.5")
+_GUSB_COMPAT_ALIAS (g_usb_context_set_main_context, "0.2.5")
+
+/* New in 0.2.9, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/cfaab3e523c11800b6d77c1d10ce0c71799a4482 */
+_GUSB_COMPAT_ALIAS (g_usb_context_wait_for_replug, "0.2.9")
 
 enum {
 	PROP_0,

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -20,12 +20,20 @@
 
 #include <libusb.h>
 
+#include "gusb-abi-compat.h"
 #include "gusb-context.h"
 #include "gusb-context-private.h"
 #include "gusb-util.h"
 #include "gusb-device.h"
 #include "gusb-device-private.h"
 #include "gusb-interface-private.h"
+
+/* New in 0.2.8, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/cfaab3e523c11800b6d77c1d10ce0c71799a4482 */
+_GUSB_COMPAT_ALIAS (g_usb_device_get_interface, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_device_get_interfaces, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_device_get_release, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_device_set_interface_alt, "0.2.8")
 
 /**
  * GUsbDevicePrivate:

--- a/gusb/gusb-endpoint.c
+++ b/gusb/gusb-endpoint.c
@@ -17,8 +17,16 @@
 
 #include "config.h"
 
+#include "gusb-abi-compat.h"
 #include "gusb-endpoint.h"
 #include "gusb-endpoint-private.h"
+
+/* New in 0.3.3, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/f8fcf4b857fb002c1da5657d8b2f639f4b5f3f67 */
+_GUSB_COMPAT_ALIAS (g_usb_endpoint_get_number, "0.3.3")
+_GUSB_COMPAT_ALIAS (g_usb_endpoint_get_refresh, "0.3.3")
+_GUSB_COMPAT_ALIAS (g_usb_endpoint_get_synch_address, "0.3.3")
+_GUSB_COMPAT_ALIAS (g_usb_endpoint_get_type, "0.3.3")
 
 struct _GUsbEndpoint
 {

--- a/gusb/gusb-interface.c
+++ b/gusb/gusb-interface.c
@@ -20,9 +20,26 @@
 
 #include <string.h>
 
+#include "gusb-abi-compat.h"
 #include "gusb-interface.h"
 #include "gusb-interface-private.h"
 #include "gusb-endpoint-private.h"
+
+/* New in 0.2.8, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/cfaab3e523c11800b6d77c1d10ce0c71799a4482 */
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_alternate, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_class, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_extra, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_index, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_kind, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_length, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_number, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_protocol, "0.2.8")
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_subclass, "0.2.8")
+
+/* New in 0.2.8, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/3ee71729cf44bdd6d4956a1aad47ea5214cd61f9 */
+_GUSB_COMPAT_ALIAS (g_usb_interface_get_type, "0.2.8")
 
 struct _GUsbInterface
 {

--- a/gusb/gusb-version.c
+++ b/gusb/gusb-version.c
@@ -7,7 +7,12 @@
 
 #include "config.h"
 
+#include "gusb-abi-compat.h"
 #include "gusb-version.h"
+
+/* New in 0.3.1, but originally versioned as 0.1.0 */
+/* https://github.com/hughsie/libgusb/commit/3bf1467c775ef889f136dd20e97fce61068e0189 */
+_GUSB_COMPAT_ALIAS (g_usb_version_string, "0.3.1")
 
 /**
  * g_usb_version_string:

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -40,6 +40,7 @@ LIBGUSB_0.1.0 {
     g_usb_device_reset;
     g_usb_device_set_configuration;
     g_usb_source_error_quark;
+    g_usb_source_set_callback;
     g_usb_strerror;
   local: *;
 };

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -42,6 +42,28 @@ LIBGUSB_0.1.0 {
     g_usb_source_error_quark;
     g_usb_source_set_callback;
     g_usb_strerror;
+    g_usb_context_get_main_context; /* really added in a later version */
+    g_usb_context_set_main_context; /* really added in a later version */
+    g_usb_context_wait_for_replug; /* really added in a later version */
+    g_usb_device_get_interface; /* really added in a later version */
+    g_usb_device_get_interfaces; /* really added in a later version */
+    g_usb_device_get_release; /* really added in a later version */
+    g_usb_device_set_interface_alt; /* really added in a later version */
+    g_usb_endpoint_get_number; /* really added in a later version */
+    g_usb_endpoint_get_refresh; /* really added in a later version */
+    g_usb_endpoint_get_synch_address; /* really added in a later version */
+    g_usb_endpoint_get_type; /* really added in a later version */
+    g_usb_interface_get_alternate; /* really added in a later version */
+    g_usb_interface_get_class; /* really added in a later version */
+    g_usb_interface_get_extra; /* really added in a later version */
+    g_usb_interface_get_index; /* really added in a later version */
+    g_usb_interface_get_kind; /* really added in a later version */
+    g_usb_interface_get_length; /* really added in a later version */
+    g_usb_interface_get_number; /* really added in a later version */
+    g_usb_interface_get_protocol; /* really added in a later version */
+    g_usb_interface_get_subclass; /* really added in a later version */
+    g_usb_interface_get_type; /* really added in a later version */
+    g_usb_version_string; /* really added in a later version */
   local: *;
 };
 

--- a/gusb/meson.build
+++ b/gusb/meson.build
@@ -41,8 +41,10 @@ install_headers([
 
 mapfile = 'libgusb.ver'
 vflag = []
+extra_cargs = []
 if host_machine.system() in ['linux', 'windows']
   vflag += '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+  extra_cargs += '-D_GUSB_VERSIONED_SYMBOLS'
 endif
 gusb = library(
   'gusb',
@@ -64,7 +66,7 @@ gusb = library(
   ],
   c_args : [
       cargs,
-    ],
+    ] + extra_cargs,
   include_directories : [
       root_incdir,
       lib_incdir,
@@ -151,7 +153,7 @@ libgusb_typelib = libgusb_girtarget[1]
 # To avoid the circular dep, and to ensure we don't change exported API
 # accidentally actually check in a version of the version script to git.
 mapfile_target = custom_target('gusb_mapfile',
-  input: libgusb_girtarget[0],
+  input: [libgusb_girtarget[0], 'gusb-abi-compat.h'],
   output: 'libgusb.ver',
   command: [
     join_paths(meson.source_root(), 'contrib', 'generate-version-script.py'),


### PR DESCRIPTION
In older versions of gusb, some symbols were mis-versioned. Avoid
breaking ABI by providing both versions - the incorrect one and the
correct one - as aliases for the same symbol.

Newly-linked programs will use the correct (later) version.

---

Includes #32 and #31, so please review those first.

This resolves #9, #27 by providing both ABIs. In `objdump -Tx` it looks like this, for example:

```
000000000000b5cf g    DF .text  000000000000009e (LIBGUSB_0.1.0) g_usb_device_get_release
000000000000b5cf g    DF .text  000000000000009e  LIBGUSB_0.2.8 g_usb_device_get_release
```

I still need to test this with the Debian packaging toolchain (which has fairly robust checks for symbols disappearing) but hopefully it will work as intended.

It's admittedly a bit ugly, but shouldn't grow any further, and the whole mess can be dropped at the next ABI break.