### PR TITLE
generate-version-script: Don't hard-code the path of python3

### DIFF
--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3
 # pylint: disable=invalid-name,missing-docstring
 #
 # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>

--- a/gusb/meson.build
+++ b/gusb/meson.build
@@ -142,6 +142,9 @@ libgusb_girtarget = gnome.generate_gir(gusb,
 libgusb_gir = libgusb_girtarget[0]
 libgusb_typelib = libgusb_girtarget[1]
 
+pymod = import('python')
+py_installation = pymod.find_installation('python3')
+
 # Verify the map file is correct -- note we can't actually use the generated
 # file for two reasons:
 #
@@ -154,6 +157,7 @@ mapfile_target = custom_target('gusb_mapfile',
   input: libgusb_girtarget[0],
   output: 'libgusb.ver',
   command: [
+    py_installation,
     join_paths(meson.source_root(), 'contrib', 'generate-version-script.py'),
     'LIBGUSB',
     '@INPUT@',


### PR DESCRIPTION
Python can be installed in different directories on different operating
systems, so we can't hard-code the path of it. Instead it, just use the
usual '#!/usr/bin/env' to find it with PATH.