### PR TITLE
Allow building GtkDoc when building as a subproject

### DIFF
--- a/docs/api/meson.build
+++ b/docs/api/meson.build
@@ -7,8 +7,8 @@ gusb_version_xml = configure_file(
 gnome.gtkdoc(
   'gusb',
   src_dir : [
-    join_paths(meson.source_root(), 'gusb'),
-    join_paths(meson.build_root(), 'gusb'),
+    gusb_source_dir,
+    gusb_build_dir,
   ],
   main_sgml : 'gusb-docs.sgml',
   install : true

--- a/gusb/meson.build
+++ b/gusb/meson.build
@@ -3,6 +3,9 @@ cargs = [
   '-DUSB_IDS="' + get_option('usb_ids') + '"',
 ]
 
+gusb_source_dir = meson.current_source_dir()
+gusb_build_dir = meson.current_build_dir()
+
 con2 = configuration_data()
 con2.set('G_USB_MAJOR_VERSION', gusb_major_version)
 con2.set('G_USB_MINOR_VERSION', gusb_minor_version)


### PR DESCRIPTION
Fixes https://github.com/fwupd/fwupd/issues/2178