### PR TITLE
Add a way to get iConfiguration

### DIFF
--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -1777,6 +1777,36 @@ g_usb_device_get_pid_as_str (GUsbDevice *device)
 }
 
 /**
+ * g_usb_device_get_configuration_index
+ * @device: a #GUsbDevice
+ *
+ * Get the index for the active Configuration string descriptor
+ * ie, iConfiguration.
+ *
+ * Return value: a string descriptor index.
+ *
+ * Since: 0.3.5
+ **/
+guint8
+g_usb_device_get_configuration_index (GUsbDevice *device)
+{
+	struct libusb_config_descriptor *config;
+	gint rc;
+	guint8 index;
+
+	g_return_val_if_fail (G_USB_IS_DEVICE (device), 0);
+
+	rc = libusb_get_active_config_descriptor (device->priv->device, &config);
+	g_return_val_if_fail (rc == 0, 0);
+
+	index = config->iConfiguration;
+
+	libusb_free_config_descriptor (config);
+	return index;
+}
+
+
+/**
  * g_usb_device_get_manufacturer_index:
  * @device: a #GUsbDevice
  *

--- a/gusb/gusb-device.h
+++ b/gusb/gusb-device.h
@@ -156,6 +156,7 @@ guint8			 g_usb_device_get_device_class	(GUsbDevice	*device);
 guint8			 g_usb_device_get_device_subclass	(GUsbDevice *device);
 guint8			 g_usb_device_get_device_protocol	(GUsbDevice *device);
 
+guint8			 g_usb_device_get_configuration_index	(GUsbDevice *device);
 guint8			 g_usb_device_get_manufacturer_index	(GUsbDevice *device);
 guint8			 g_usb_device_get_product_index		(GUsbDevice *device);
 guint8			 g_usb_device_get_serial_number_index	(GUsbDevice *device);

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -141,3 +141,9 @@ LIBGUSB_0.3.3 {
     g_usb_interface_get_endpoints;
   local: *;
 } LIBGUSB_0.3.1;
+
+LIBGUSB_0.3.5 {
+  global:
+    g_usb_device_get_configuration_index;
+  local: *;
+} LIBGUSB_0.3.3;


### PR DESCRIPTION
Adds a getter for a gusb_device to get the string index for the active
configuration's description.