### PR TITLE
Properly set dylib versions on darwin

### DIFF
--- a/gusb/meson.build
+++ b/gusb/meson.build
@@ -61,6 +61,7 @@ gusb = library(
   ],
   soversion : lt_current,
   version : lt_version,
+  darwin_versions: [lt_current + 1, '@0@.@1@.0'.format(lt_current + 1, lt_revision)],
   dependencies : [
     libgio,
     libusb,

--- a/meson.build
+++ b/meson.build
@@ -15,9 +15,9 @@ conf = configuration_data()
 conf.set_quoted('VERSION', gusb_version)
 
 # libtool versioning - this applies to libgusb
-lt_current = '2'
-lt_revision = '10'
-lt_age = '0'
+lt_current = 2
+lt_revision = 10
+lt_age = 0
 lt_version = '@0@.@1@.@2@'.format(lt_current, lt_age, lt_revision)
 
 # get supported warning flags


### PR DESCRIPTION
This is a replacement/alternative to #38. The build in that PR is failing because Homebrew currently builds `libgusb` using an older, patched version of `meson` that does some magic with macOS dylib versioning. We've had to use this because it turns out that as many projects transitioned from `autotools` to `meson`, dylib versioning broke - the switch would often result in a perceived downgrade of the dylib version when this was not the case.

This PR fixes the dylib versioning issue, which will allow us at Homebrew to build with a non-patched, current `meson`, which will eliminate the need for the changes proposed in #38. For context, some other projects (notably GNOME) have implemented similar fixes:
- https://gitlab.gnome.org/GNOME/gtk/commit/e65699e9c167b08b8ce3cea5d3abbdf525137eac
- https://gitlab.gnome.org/GNOME/atk/-/commit/d6f50489d8f488e6fa84fad63f2a25973e4d3d5b

The downstream PR at Homebrew that may provide more information is at https://github.com/Homebrew/homebrew-core/pull/58926.