### PR TITLE
Add g_usb_device_get_string_descriptor_bytes()

### DIFF
--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -889,6 +889,47 @@ g_usb_device_get_string_descriptor (GUsbDevice  *device,
 	return g_strdup ((const gchar *)buf);
 }
 
+/**
+ * g_usb_device_get_string_descriptor_bytes:
+ * @desc_index: the index for the string descriptor to retrieve
+ * @langid: the language ID
+ * @error: a #GError, or %NULL
+ *
+ * Get a raw string descriptor from the device. The returned string should be freed
+ * with g_bytes_unref() when no longer needed.
+ *
+ * Return value: (transfer full): a possibly UTF-16 string, or NULL on error.
+ *
+ * Since: 0.3.6
+ **/
+GBytes *
+g_usb_device_get_string_descriptor_bytes (GUsbDevice  *device,
+					  guint8       desc_index,
+					  guint16      langid,
+					  GError     **error)
+{
+	gint rc;
+	unsigned char buf[128];
+
+	g_return_val_if_fail (G_USB_IS_DEVICE (device), NULL);
+	g_return_val_if_fail (error == NULL || *error == NULL, NULL);
+
+	if (device->priv->handle == NULL) {
+		g_usb_device_not_open_error (device, error);
+		return NULL;
+	}
+
+	rc = libusb_get_string_descriptor (device->priv->handle,
+					   desc_index, langid,
+					   buf, sizeof(buf));
+	if (rc < 0) {
+		g_usb_device_libusb_error_to_gerror (device, rc, error);
+		return NULL;
+	}
+
+	return g_bytes_new (buf, rc);
+}
+
 typedef gssize (GUsbDeviceTransferFinishFunc) (GUsbDevice *device, GAsyncResult *res, GError **error);
 
 typedef struct {

--- a/gusb/gusb-device.h
+++ b/gusb/gusb-device.h
@@ -118,6 +118,17 @@ typedef enum {
 	G_USB_DEVICE_CLASS_VENDOR_SPECIFIC		= 0xff
 } GUsbDeviceClassCode;
 
+
+/**
+ * GUsbDeviceLangid:
+ *
+ * The USB language ID.
+ **/
+typedef enum {
+	G_USB_DEVICE_LANGID_INVALID			= 0x0000,
+	G_USB_DEVICE_LANGID_ENGLISH_UNITED_STATES	= 0x0409,
+} GUsbDeviceLangid;
+
 struct _GUsbDevice
 {
 	 GObject			 parent;
@@ -203,6 +214,10 @@ gboolean		 g_usb_device_set_interface_alt	(GUsbDevice	*device,
 
 gchar			*g_usb_device_get_string_descriptor (GUsbDevice *device,
 							 guint8		 desc_index,
+							 GError		**error);
+GBytes			*g_usb_device_get_string_descriptor_bytes (GUsbDevice *device,
+							 guint8		 desc_index,
+							 guint16	 langid,
 							 GError		**error);
 
 /* sync -- TODO: use GCancellable and GUsbSource */

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -147,3 +147,9 @@ LIBGUSB_0.3.5 {
     g_usb_device_get_configuration_index;
   local: *;
 } LIBGUSB_0.3.3;
+
+LIBGUSB_0.3.6 {
+  global:
+    g_usb_device_get_string_descriptor_bytes;
+  local: *;
+} LIBGUSB_0.3.5;


### PR DESCRIPTION
This is requried for the GD32VF103 device.