### PR TITLE
device: Do not double-reference USB devices

### DIFF
--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -146,8 +146,6 @@ g_usb_device_constructed (GObject *object)
 	if (!priv->device)
 		g_error("constructed without a libusb_device");
 
-	libusb_ref_device(priv->device);
-
 	rc = libusb_get_device_descriptor (priv->device, &priv->desc);
 	if (rc != LIBUSB_SUCCESS)
 		g_warning ("Failed to get USB descriptor for device: %s",

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -110,6 +110,18 @@ g_usb_device_get_property (GObject    *object,
 }
 
 static void
+set_libusb_device (GUsbDevice           *device,
+		   struct libusb_device *dev)
+{
+	GUsbDevicePrivate *priv = device->priv;
+
+	g_clear_pointer (&priv->device, libusb_unref_device);
+
+	if (dev != NULL)
+		priv->device = libusb_ref_device (dev);
+}
+
+static void
 g_usb_device_set_property (GObject      *object,
 			   guint	 prop_id,
 			   const GValue *value,
@@ -120,7 +132,7 @@ g_usb_device_set_property (GObject      *object,
 
 	switch (prop_id) {
 	case PROP_LIBUSB_DEVICE:
-		priv->device = g_value_get_pointer (value);
+		set_libusb_device (device, g_value_get_pointer (value));
 		break;
 	case PROP_CONTEXT:
 		priv->context = g_value_dup_object (value);
@@ -238,8 +250,6 @@ g_usb_device_initable_init (GInitable     *initable,
 				     "Constructed without a libusb_device");
 		return FALSE;
 	}
-
-	libusb_ref_device (priv->device);
 
 	rc = libusb_get_device_descriptor (priv->device, &priv->desc);
 	if (rc != LIBUSB_SUCCESS) {


### PR DESCRIPTION
Currently gusb-device adds two references to an internal libusb device,
causing a memory leak on destruction.

In fact, we add a reference when the device is constructed and when the
device is inited.

To avoid this and ensure that libusb will cleanup all the devices on
context destruction, only reference on device initialization.

---

As context, in [libfprint we had this leak](https://gitlab.freedesktop.org/3v1n0/libfprint/-/jobs/8831654/artifacts/file/_build/meson-logs/testlog-valgrind.txt) for some long time, and I initially thought was due to libusb... But it's not the case, in fact using libusb in debug mode will warn about the application not releasing a device.

```
==326037== 
==326037== HEAP SUMMARY:
==326037==     in use at exit: 1,206,244 bytes in 3,664 blocks
==326037==   total heap usage: 13,729 allocs, 10,065 frees, 15,130,225 bytes allocated
==326037== 
==326037== 3,386 (800 direct, 2,586 indirect) bytes in 5 blocks are definitely lost in loss record 1,558 of 1,594
==326037==    at 0x4847A25: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==326037==    by 0xA3AF1F8: usbi_alloc_device (core.c:702)
==326037==    by 0xA3B0641: linux_enumerate_device.isra.0 (linux_usbfs.c:1120)
==326037==    by 0xA3B0DAC: UnknownInlinedFun (linux_udev.c:299)
==326037==    by 0xA3B0DAC: UnknownInlinedFun (linux_usbfs.c:467)
==326037==    by 0xA3B0DAC: op_init (linux_usbfs.c:417)
==326037==    by 0xA3AFA8A: libusb_init (core.c:2316)
==326037==    by 0x7288DB2: g_usb_context_initable_init (gusb-context.c:601)
==326037==    by 0x6454969: g_initable_new_valist (ginitable.c:248)
==326037==    by 0x6454A1C: g_initable_new (ginitable.c:162)
==326037==    by 0x731E690: fp_context_init (fp-context.c:358)
==326037==    by 0x62DF089: g_type_create_instance (gtype.c:1921)
==326037==    by 0x62C4ABC: g_object_new_internal (gobject.c:1939)
==326037==    by 0x62C5FCC: g_object_new_with_properties (gobject.c:2108)
==326037== 
==326037== LEAK SUMMARY:
==326037==    definitely lost: 800 bytes in 5 blocks
==326037==    indirectly lost: 2,586 bytes in 19 blocks
==326037==      possibly lost: 0 bytes in 0 blocks
==326037==    still reachable: 97,986 bytes in 597 blocks
==326037==         suppressed: 1,090,128 bytes in 2,898 blocks
==326037== Reachable blocks (those to which a pointer was found) are not shown.
==326037== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==326037== 
==326037== For lists of detected and suppressed errors, rerun with: -s
==326037== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 2697 from 418)
```