### PR TITLE
Add g_usb_device_get_string_descriptor_bytes_full

### DIFF
--- a/gusb/gusb-device.h
+++ b/gusb/gusb-device.h
@@ -212,13 +212,18 @@ gboolean		 g_usb_device_set_interface_alt	(GUsbDevice	*device,
 							 guint8		 alt,
 							 GError		**error);
 
-gchar			*g_usb_device_get_string_descriptor (GUsbDevice *device,
-							 guint8		 desc_index,
-							 GError		**error);
-GBytes			*g_usb_device_get_string_descriptor_bytes (GUsbDevice *device,
-							 guint8		 desc_index,
-							 guint16	 langid,
-							 GError		**error);
+gchar			*g_usb_device_get_string_descriptor		(GUsbDevice	*device,
+									 guint8		 desc_index,
+									 GError		**error);
+GBytes			*g_usb_device_get_string_descriptor_bytes	(GUsbDevice	*device,
+									 guint8		 desc_index,
+									 guint16	 langid,
+									 GError		**error);
+GBytes			*g_usb_device_get_string_descriptor_bytes_full	(GUsbDevice	*device,
+									 guint8		 desc_index,
+									 guint16	 langid,
+									 gsize		 length,
+									 GError		**error);
 
 /* sync -- TODO: use GCancellable and GUsbSource */
 gboolean		 g_usb_device_control_transfer	(GUsbDevice	*device,

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -153,3 +153,9 @@ LIBGUSB_0.3.6 {
     g_usb_device_get_string_descriptor_bytes;
   local: *;
 } LIBGUSB_0.3.5;
+
+LIBGUSB_0.3.8 {
+  global:
+    g_usb_device_get_string_descriptor_bytes_full;
+  local: *;
+} LIBGUSB_0.3.6;


### PR DESCRIPTION
Some devices won't answer to a request with a 128-byte data buffer, this
allows the user to specify the size of the request data
buffer. g_usb_device_get_string_descriptor_bytes still uses the default
buffer size (128 bytes).