### PR TITLE
Fix hotplug after threaded device removal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,14 +23,14 @@ jobs:
       - run: docker run -t -v `pwd`:/build libgusb-${{ matrix.distro }} ./contrib/ci/build_and_test.sh -Dtests=false
 
   build-freebsd:
-    runs-on: macos-latest
+    runs-on: macos-10.15
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build
       id: test
-      uses: vmactions/freebsd-vm@v0.1.4
+      uses: vmactions/freebsd-vm@v0.1.5
       with:
         usesh: true
         mem: 8192

--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -407,7 +407,7 @@ g_usb_context_hotplug_cb (struct libusb_context *ctx,
 	GUsbContextIdleHelper *helper;
 
 	helper = g_new0 (GUsbContextIdleHelper, 1);
-	helper->context = context;
+	helper->context = g_object_ref (context);
 	helper->dev = libusb_ref_device (dev);
 	helper->event = event;
 


### PR DESCRIPTION
Somehow this worked when we unref'd the context but did not ref it.