### PR TITLE
Cache the list of interfaces and descriptors

### DIFF
--- a/gusb/gusb-device.h
+++ b/gusb/gusb-device.h
@@ -205,6 +205,8 @@ g_usb_device_close(GUsbDevice *self, GError **error);
 
 gboolean
 g_usb_device_reset(GUsbDevice *self, GError **error);
+void
+g_usb_device_invalidate(GUsbDevice *self);
 
 gint
 g_usb_device_get_configuration(GUsbDevice *self, GError **error);

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -174,5 +174,6 @@ LIBGUSB_0.4.0 {
     g_usb_bos_descriptor_get_type;
     g_usb_device_get_bos_descriptor;
     g_usb_device_get_bos_descriptors;
+    g_usb_device_invalidate;
   local: *;
 } LIBGUSB_0.3.10;


### PR DESCRIPTION
This can speed up device enumeration, and also allows us to emulate the
interfaces or descriptors in the future.