### PR TITLE
Allow emulating failed events

### DIFF
--- a/gusb/gusb-device-event-private.h
+++ b/gusb/gusb-device-event-private.h
@@ -17,6 +17,8 @@ GUsbDeviceEvent *
 _g_usb_device_event_new(const gchar *id);
 void
 _g_usb_device_event_set_bytes_raw(GUsbDeviceEvent *self, gconstpointer buf, gsize bufsz);
+void
+_g_usb_device_event_set_status(GUsbDeviceEvent *self, gint status);
 
 gboolean
 _g_usb_device_event_load(GUsbDeviceEvent *self, JsonObject *json_object, GError **error);

--- a/gusb/gusb-device-event.h
+++ b/gusb/gusb-device-event.h
@@ -18,6 +18,8 @@ const gchar *
 g_usb_device_event_get_id(GUsbDeviceEvent *self);
 GBytes *
 g_usb_device_event_get_bytes(GUsbDeviceEvent *self);
+gint
+g_usb_device_event_get_status(GUsbDeviceEvent *self);
 void
 g_usb_device_event_set_bytes(GUsbDeviceEvent *self, GBytes *bytes);
 

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -176,6 +176,7 @@ LIBGUSB_0.4.0 {
     g_usb_context_save;
     g_usb_device_event_get_bytes;
     g_usb_device_event_get_id;
+    g_usb_device_event_get_status;
     g_usb_device_event_get_type;
     g_usb_device_event_set_bytes;
     g_usb_device_get_bos_descriptor;


### PR DESCRIPTION
This is required to emulate devices that just reset (without completing the current transfer) when asked to reset.