### PR TITLE
Allow adding tags to the JSON device event

### DIFF
--- a/gusb/gusb-device-private.h
+++ b/gusb/gusb-device-private.h
@@ -22,5 +22,7 @@ libusb_device *
 _g_usb_device_get_device(GUsbDevice *self);
 gboolean
 _g_usb_device_open_internal(GUsbDevice *self, GError **error);
+gboolean
+_g_usb_device_has_tag(GUsbDevice *self, const gchar *tag);
 
 G_END_DECLS

--- a/gusb/gusb-device.h
+++ b/gusb/gusb-device.h
@@ -170,6 +170,9 @@ g_usb_device_get_device_subclass(GUsbDevice *self);
 guint8
 g_usb_device_get_device_protocol(GUsbDevice *self);
 
+void
+g_usb_device_add_tag(GUsbDevice *self, const gchar *tag);
+
 guint8
 g_usb_device_get_configuration_index(GUsbDevice *self);
 guint8

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -185,3 +185,9 @@ LIBGUSB_0.4.0 {
     g_usb_device_invalidate;
   local: *;
 } LIBGUSB_0.3.10;
+
+LIBGUSB_0.4.1 {
+  global:
+    g_usb_device_add_tag;
+  local: *;
+} LIBGUSB_0.4.0;


### PR DESCRIPTION
This allows us to see which phase of the emulation should be used.