### PR TITLE
Fix g_usb_interface save and load

### DIFF
--- a/gusb/gusb-interface.c
+++ b/gusb/gusb-interface.c
@@ -152,7 +152,7 @@ _g_usb_interface_save(GUsbInterface *self, JsonBuilder *json_builder, GError **e
 	}
 
 	/* array of endpoints */
-	if (self->endpoints->len > 0) {
+	if (self->endpoints != NULL && self->endpoints->len > 0) {
 		json_builder_set_member_name(json_builder, "UsbEndpoints");
 		json_builder_begin_array(json_builder);
 		for (guint i = 0; i < self->endpoints->len; i++) {


### PR DESCRIPTION
When the g_usb_interface is created from _g_usb_device_load(), self->endpoints may not be initialized.

Load GUsb endpoints when loading interface.