### PR TITLE
Save the libusb error if libusb_submit_transfer() fails

### DIFF
--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -401,7 +401,8 @@ g_usb_context_load_with_tag(GUsbContext *self,
 {
 	GUsbContextPrivate *priv = GET_PRIVATE(self);
 	JsonArray *json_array;
-	g_autoptr(GPtrArray) devices_to_remove = g_ptr_array_new_with_free_func((GDestroyNotify) g_object_unref);
+	g_autoptr(GPtrArray) devices_to_remove =
+	    g_ptr_array_new_with_free_func((GDestroyNotify)g_object_unref);
 
 	g_return_val_if_fail(G_USB_IS_CONTEXT(self), FALSE);
 	g_return_val_if_fail(json_object != NULL, FALSE);

--- a/gusb/gusb-device-event-private.h
+++ b/gusb/gusb-device-event-private.h
@@ -19,6 +19,8 @@ void
 _g_usb_device_event_set_bytes_raw(GUsbDeviceEvent *self, gconstpointer buf, gsize bufsz);
 void
 _g_usb_device_event_set_status(GUsbDeviceEvent *self, gint status);
+void
+_g_usb_device_event_set_rc(GUsbDeviceEvent *self, gint rc);
 
 gboolean
 _g_usb_device_event_load(GUsbDeviceEvent *self, JsonObject *json_object, GError **error);

--- a/gusb/gusb-device-event.h
+++ b/gusb/gusb-device-event.h
@@ -20,6 +20,8 @@ GBytes *
 g_usb_device_event_get_bytes(GUsbDeviceEvent *self);
 gint
 g_usb_device_event_get_status(GUsbDeviceEvent *self);
+gint
+g_usb_device_event_get_rc(GUsbDeviceEvent *self);
 void
 g_usb_device_event_set_bytes(GUsbDeviceEvent *self, GBytes *bytes);
 

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -959,6 +959,10 @@ g_usb_device_get_custom_index(GUsbDevice *self,
 				    event_id);
 			return 0x00;
 		}
+		if (!g_usb_device_libusb_error_to_gerror(self,
+							 g_usb_device_event_get_rc(event),
+							 error))
+			return 0x00;
 		bytes = g_usb_device_event_get_bytes(event);
 		if (bytes == NULL || g_bytes_get_size(bytes) != 1) {
 			g_set_error(error,
@@ -1611,6 +1615,10 @@ g_usb_device_get_string_descriptor(GUsbDevice *self, guint8 desc_index, GError *
 				    event_id);
 			return NULL;
 		}
+		if (!g_usb_device_libusb_error_to_gerror(self,
+							 g_usb_device_event_get_rc(event),
+							 error))
+			return NULL;
 		bytes = g_usb_device_event_get_bytes(event);
 		if (bytes == NULL) {
 			g_set_error(error,
@@ -1694,6 +1702,10 @@ g_usb_device_get_string_descriptor_bytes_full(GUsbDevice *self,
 				    event_id);
 			return NULL;
 		}
+		if (!g_usb_device_libusb_error_to_gerror(self,
+							 g_usb_device_event_get_rc(event),
+							 error))
+			return 0x00;
 		bytes = g_usb_device_event_get_bytes(event);
 		if (bytes == NULL) {
 			g_set_error(error,
@@ -2199,9 +2211,11 @@ g_usb_device_control_transfer_async(GUsbDevice *self,
 						event_id);
 			return;
 		}
-		if (g_usb_device_event_get_status(event) != LIBUSB_TRANSFER_COMPLETED) {
-			g_usb_device_libusb_status_to_gerror(g_usb_device_event_get_status(event),
-							     &error);
+		if (!g_usb_device_libusb_error_to_gerror(self,
+							 g_usb_device_event_get_rc(event),
+							 &error) ||
+		    !g_usb_device_libusb_status_to_gerror(g_usb_device_event_get_status(event),
+							  &error)) {
 			g_task_report_error(self,
 					    callback,
 					    user_data,
@@ -2283,6 +2297,8 @@ g_usb_device_control_transfer_async(GUsbDevice *self,
 	/* submit transfer */
 	rc = libusb_submit_transfer(req->transfer);
 	if (rc < 0) {
+		if (event != NULL)
+			_g_usb_device_event_set_rc(event, rc);
 		g_usb_device_libusb_error_to_gerror(self, rc, &error);
 		g_task_return_error(task, error);
 		g_object_unref(task);
@@ -2386,9 +2402,11 @@ g_usb_device_bulk_transfer_async(GUsbDevice *self,
 						event_id);
 			return;
 		}
-		if (g_usb_device_event_get_status(event) != LIBUSB_TRANSFER_COMPLETED) {
-			g_usb_device_libusb_status_to_gerror(g_usb_device_event_get_status(event),
-							     &error);
+		if (!g_usb_device_libusb_error_to_gerror(self,
+							 g_usb_device_event_get_rc(event),
+							 &error) ||
+		    !g_usb_device_libusb_status_to_gerror(g_usb_device_event_get_status(event),
+							  &error)) {
 			g_task_report_error(self,
 					    callback,
 					    user_data,
@@ -2459,6 +2477,8 @@ g_usb_device_bulk_transfer_async(GUsbDevice *self,
 	/* submit transfer */
 	rc = libusb_submit_transfer(req->transfer);
 	if (rc < 0) {
+		if (event != NULL)
+			_g_usb_device_event_set_rc(event, rc);
 		g_usb_device_libusb_error_to_gerror(self, rc, &error);
 		g_task_return_error(task, error);
 		g_object_unref(task);
@@ -2562,9 +2582,11 @@ g_usb_device_interrupt_transfer_async(GUsbDevice *self,
 						event_id);
 			return;
 		}
-		if (g_usb_device_event_get_status(event) != LIBUSB_TRANSFER_COMPLETED) {
-			g_usb_device_libusb_status_to_gerror(g_usb_device_event_get_status(event),
-							     &error);
+		if (!g_usb_device_libusb_error_to_gerror(self,
+							 g_usb_device_event_get_rc(event),
+							 &error) ||
+		    !g_usb_device_libusb_status_to_gerror(g_usb_device_event_get_status(event),
+							  &error)) {
 			g_task_report_error(self,
 					    callback,
 					    user_data,
@@ -2635,6 +2657,8 @@ g_usb_device_interrupt_transfer_async(GUsbDevice *self,
 	/* submit transfer */
 	rc = libusb_submit_transfer(req->transfer);
 	if (rc < 0) {
+		if (event != NULL)
+			_g_usb_device_event_set_rc(event, rc);
 		g_usb_device_libusb_error_to_gerror(self, rc, &error);
 		g_task_return_error(task, error);
 		g_object_unref(task);

--- a/gusb/libgusb.ver
+++ b/gusb/libgusb.ver
@@ -211,6 +211,7 @@ LIBGUSB_0.4.4 {
 
 LIBGUSB_0.4.5 {
   global:
+    g_usb_device_event_get_rc;
     g_usb_device_get_created;
   local: *;
 } LIBGUSB_0.4.4;


### PR DESCRIPTION
If the return code is LIBUSB_ERROR_NO_DEVICE we want to record that.