### PR TITLE
Add json_object_get_*_member_with_default() helpers

### DIFF
--- a/gusb/gusb-bos-descriptor.c
+++ b/gusb/gusb-bos-descriptor.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "gusb-bos-descriptor-private.h"
+#include "gusb-json-common.h"
 
 struct _GUsbBosDescriptor {
 	GObject parent_instance;
@@ -62,7 +63,6 @@ _g_usb_bos_descriptor_load(GUsbBosDescriptor *self, JsonObject *json_object, GEr
 	g_return_val_if_fail(json_object != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
-#if JSON_CHECK_VERSION(1, 6, 0)
 	/* optional properties */
 	self->bos_cap.bDevCapabilityType =
 	    json_object_get_int_member_with_default(json_object, "DevCapabilityType", 0x0);
@@ -76,13 +76,6 @@ _g_usb_bos_descriptor_load(GUsbBosDescriptor *self, JsonObject *json_object, GEr
 			g_bytes_unref(self->extra);
 		self->extra = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
 	}
-#else
-	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
-			    "json-glib version too old");
-	return FALSE;
-#endif
 
 	/* success */
 	return TRUE;

--- a/gusb/gusb-device-event.c
+++ b/gusb/gusb-device-event.c
@@ -13,6 +13,7 @@
 #include "config.h"
 
 #include "gusb-device-event-private.h"
+#include "gusb-json-common.h"
 
 struct _GUsbDeviceEvent {
 	GObject parent_instance;
@@ -57,7 +58,6 @@ _g_usb_device_event_load(GUsbDeviceEvent *self, JsonObject *json_object, GError 
 	g_return_val_if_fail(json_object != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
-#if JSON_CHECK_VERSION(1, 6, 0)
 	/* optional properties */
 	self->id = g_strdup(json_object_get_string_member_with_default(json_object, "Id", NULL));
 	self->status = json_object_get_int_member_with_default(json_object,
@@ -72,13 +72,6 @@ _g_usb_device_event_load(GUsbDeviceEvent *self, JsonObject *json_object, GError 
 		g_autofree guchar *buf = g_base64_decode(str, &bufsz);
 		self->bytes = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
 	}
-#else
-	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
-			    "json-glib version too old");
-	return FALSE;
-#endif
 
 	/* success */
 	return TRUE;

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -25,6 +25,7 @@
 #include "gusb-device-private.h"
 #include "gusb-interface-private.h"
 #include "gusb-util.h"
+#include "gusb-json-common.h"
 
 /**
  * GUsbDevicePrivate:
@@ -242,7 +243,6 @@ _g_usb_device_load(GUsbDevice *self, JsonObject *json_object, GError **error)
 	g_return_val_if_fail(json_object != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-#if JSON_CHECK_VERSION(1, 6, 0)
 	/* optional properties */
 	tmp = json_object_get_string_member_with_default(json_object, "PlatformId", NULL);
 	if (tmp != NULL) {
@@ -281,13 +281,6 @@ _g_usb_device_load(GUsbDevice *self, JsonObject *json_object, GError **error)
 	priv->desc.iProduct = json_object_get_int_member_with_default(json_object, "Product", 0x0);
 	priv->desc.iSerialNumber =
 	    json_object_get_int_member_with_default(json_object, "SerialNumber", 0x0);
-#else
-	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
-			    "json-glib version too old");
-	return FALSE;
-#endif
 
 	/* array of BOS descriptors */
 	if (json_object_has_member(json_object, "UsbBosDescriptors")) {

--- a/gusb/gusb-endpoint.c
+++ b/gusb/gusb-endpoint.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "gusb-endpoint-private.h"
+#include "gusb-json-common.h"
 
 struct _GUsbEndpoint {
 	GObject parent_instance;
@@ -62,7 +63,6 @@ _g_usb_endpoint_load(GUsbEndpoint *self, JsonObject *json_object, GError **error
 	g_return_val_if_fail(json_object != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, FALSE);
 
-#if JSON_CHECK_VERSION(1, 6, 0)
 	/* optional properties */
 	self->endpoint_descriptor.bDescriptorType =
 	    json_object_get_int_member_with_default(json_object, "DescriptorType", 0x0);
@@ -86,13 +86,6 @@ _g_usb_endpoint_load(GUsbEndpoint *self, JsonObject *json_object, GError **error
 			g_bytes_unref(self->extra);
 		self->extra = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
 	}
-#else
-	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
-			    "json-glib version too old");
-	return FALSE;
-#endif
 
 	/* success */
 	return TRUE;

--- a/gusb/gusb-interface.c
+++ b/gusb/gusb-interface.c
@@ -22,6 +22,7 @@
 
 #include "gusb-endpoint-private.h"
 #include "gusb-interface-private.h"
+#include "gusb-json-common.h"
 
 struct _GUsbInterface {
 	GObject parent_instance;
@@ -69,7 +70,6 @@ _g_usb_interface_load(GUsbInterface *self, JsonObject *json_object, GError **err
 	g_return_val_if_fail(json_object != NULL, FALSE);
 	g_return_val_if_fail(error == NULL || *error == NULL, -1);
 
-#if JSON_CHECK_VERSION(1, 6, 0)
 	/* optional properties */
 	self->iface.bLength = json_object_get_int_member_with_default(json_object, "Length", 0x0);
 	self->iface.bDescriptorType =
@@ -110,13 +110,6 @@ _g_usb_interface_load(GUsbInterface *self, JsonObject *json_object, GError **err
 			g_bytes_unref(self->extra);
 		self->extra = g_bytes_new_take(g_steal_pointer(&buf), bufsz);
 	}
-#else
-	g_set_error_literal(error,
-			    G_IO_ERROR,
-			    G_IO_ERROR_NOT_SUPPORTED,
-			    "json-glib version too old");
-	return FALSE;
-#endif
 
 	/* success */
 	return TRUE;

--- a/gusb/gusb-json-common.c
+++ b/gusb/gusb-json-common.c
@@ -1,0 +1,27 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2023 Collabora Ltd.
+ *    @author Frédéric Danis <frederic.danis@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#include "config.h"
+
+#include "gusb-json-common.h"
+
+#if ! JSON_CHECK_VERSION(1, 6, 0)
+const char *json_object_get_string_member_with_default(JsonObject *json_object, const char* member_name, const char* default_value)
+{
+	if (!json_object_has_member(json_object, member_name))
+		return default_value;
+	return json_object_get_string_member(json_object, member_name);
+}
+
+gint64 json_object_get_int_member_with_default(JsonObject *json_object, const char* member_name, gint64 default_value)
+{
+	if (!json_object_has_member(json_object, member_name))
+		return default_value;
+	return json_object_get_int_member(json_object, member_name);
+}
+#endif

--- a/gusb/gusb-json-common.h
+++ b/gusb/gusb-json-common.h
@@ -1,0 +1,21 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: t; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2023 Collabora Ltd.
+ *    @author Frédéric Danis <frederic.danis@collabora.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1+
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <json-glib/json-glib.h>
+
+G_BEGIN_DECLS
+
+#if ! JSON_CHECK_VERSION(1, 6, 0)
+const char *json_object_get_string_member_with_default(JsonObject *json_object, const char* member_name, const char* default_value);
+gint64 json_object_get_int_member_with_default(JsonObject *json_object, const char* member_name, gint64 default_value);
+#endif
+
+G_END_DECLS

--- a/gusb/meson.build
+++ b/gusb/meson.build
@@ -64,6 +64,7 @@ gusb = library(
     'gusb-source.c',
     'gusb-util.c',
     'gusb-version.c',
+    'gusb-json-common.c',
   ],
   soversion : lt_current,
   version : lt_version,
@@ -214,6 +215,7 @@ if get_option('tests')
       'gusb-self-test.c',
       'gusb-source.c',
       'gusb-util.c',
+      'gusb-json-common.c'
     ],
     include_directories : [
       root_incdir,


### PR DESCRIPTION
json library previous to version 1.6.0 doesn't provide the `json_object_get_*_member_with_default()` functions.