### PR TITLE
Fix BulkTransfer out-of-order reply

### DIFF
--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -887,6 +887,7 @@ g_usb_device_load_event(GUsbDevice *self, const gchar *id)
 		if (g_strcmp0(g_usb_device_event_get_id(event), id) == 0) {
 			if (_g_usb_context_has_flag(priv->context, G_USB_CONTEXT_FLAGS_DEBUG))
 				g_debug("found out-of-order %s at position %u", id, i);
+			priv->event_idx = i + 1;
 			return event;
 		}
 	}


### PR DESCRIPTION
The reply to an out-of-order outgoing BulkTransfer may be also out-of-order.

Currently we can get:
```
found in-order BulkTransfer:Endpoint=0x01,Data=…,Length=0x25 at position 315
found in-order BulkTransfer:Endpoint=0x82,Data=…,Length=0x25 at position 316
…
found out-of-order BulkTransfer:Endpoint=0x01,Data=…,Length=0x25 at position 312
found in-order BulkTransfer:Endpoint=0x82,Data=…,Length=0x25 at position 320
```

while expecting:
```
found in-order BulkTransfer:Endpoint=0x01,Data=…,Length=0x25 at position 315
found in-order BulkTransfer:Endpoint=0x82,Data=…,Length=0x25 at position 316
…
found out-of-order BulkTransfer:Endpoint=0x01,Data=…,Length=0x25 at position 312
found in-order BulkTransfer:Endpoint=0x82,Data=…,Length=0x25 at position 314
…
found in-order BulkTransfer:Endpoint=0x01,Data=…,Length=0x25 at position 319
found in-order BulkTransfer:Endpoint=0x82,Data=…,Length=0x25 at position 320
```