### PR TITLE
Add calling convention to libusb callback functions

### DIFF
--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -654,7 +654,7 @@ g_usb_context_idle_hotplug_cb(gpointer user_data)
 }
 
 /* this is run in the libusb thread */
-static int
+static int LIBUSB_CALL
 g_usb_context_hotplug_cb(struct libusb_context *ctx,
 			 struct libusb_device *dev,
 			 libusb_hotplug_event event,

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -2049,7 +2049,7 @@ g_usb_device_libusb_status_to_gerror(gint status, GError **error)
 	return ret;
 }
 
-static void
+static void LIBUSB_CALL
 g_usb_device_async_transfer_cb(struct libusb_transfer *transfer)
 {
 	GTask *task = transfer->user_data;
@@ -2081,7 +2081,7 @@ g_usb_device_cancelled_cb(GCancellable *cancellable, GcmDeviceReq *req)
 	libusb_cancel_transfer(req->transfer);
 }
 
-static void
+static void LIBUSB_CALL
 g_usb_device_control_transfer_cb(struct libusb_transfer *transfer)
 {
 	GTask *task = transfer->user_data;


### PR DESCRIPTION
```

    This fixes compiling with clang 16 in 32 bit mingw environment.

    Here is the compiler error:
    ../gusb/gusb-device.c:2298:10: error: incompatible function pointer types passing
    'void (struct libusb_transfer *)' to parameter of type 'libusb_transfer_cb_fn'
    (aka 'void (*)(struct libusb_transfer *) __attribute__((stdcall))')
    [-Wincompatible-function-pointer-types]
```
