### PR TITLE
trivial: Update GitHub Actions versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: docker build -t libgusb-${{ matrix.distro }} -f contrib/ci/Dockerfile-${{ matrix.distro }} .
       - run: docker run -t -v `pwd`:/build libgusb-${{ matrix.distro }} ./contrib/ci/build_and_test.sh -Dtests=false
 
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build
       id: test
       uses: vmactions/freebsd-vm@v0.2.6


### PR DESCRIPTION
Node.js 12 actions are deprecated. These actions are using Node.js 16.