### PR TITLE
license: s/LGPL-2.1+/LGPL-2.1-or-later/g

### DIFF
--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2017 Richard Hughes <richard@hughsie.com>
 #
-# SPDX-License-Identifier: LGPL-2.1+
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 import sys
 import xml.etree.ElementTree as ET

--- a/gusb/gusb-bos-descriptor-private.h
+++ b/gusb/gusb-bos-descriptor-private.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-bos-descriptor.c
+++ b/gusb/gusb-bos-descriptor.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-bos-descriptor.h
+++ b/gusb/gusb-bos-descriptor.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-context-private.h
+++ b/gusb/gusb-context-private.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-context.c
+++ b/gusb/gusb-context.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-context.h
+++ b/gusb/gusb-context.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-device-event-private.h
+++ b/gusb/gusb-device-event-private.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-device-event.c
+++ b/gusb/gusb-device-event.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-device-event.h
+++ b/gusb/gusb-device-event.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-device-list.c
+++ b/gusb/gusb-device-list.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-device-list.h
+++ b/gusb/gusb-device-list.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-device-private.h
+++ b/gusb/gusb-device-private.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-device.c
+++ b/gusb/gusb-device.c
@@ -4,7 +4,7 @@
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  * Copyright (C) 2011 Debarshi Ray <debarshir@src.gnome.org>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-device.h
+++ b/gusb/gusb-device.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-endpoint-private.h
+++ b/gusb/gusb-endpoint-private.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2020 Emmanuel Pacaud <emmanuel@gnome.org>
  * Copyright (C) 2022 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-endpoint.c
+++ b/gusb/gusb-endpoint.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2020 Emmanuel Pacaud <emmanuel@gnome.org>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-endpoint.h
+++ b/gusb/gusb-endpoint.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2020 Emmanuel Pacaud <emmanuel@gnome.org>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-interface-private.h
+++ b/gusb/gusb-interface-private.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-interface.c
+++ b/gusb/gusb-interface.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 Emmanuel Pacaud <emmanuel@gnome.org>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-interface.h
+++ b/gusb/gusb-interface.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2015 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2020 Emmanuel Pacaud <emmanuel@gnome.org>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-json-common.c
+++ b/gusb/gusb-json-common.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2023 Collabora Ltd.
  *    @author Frédéric Danis <frederic.danis@collabora.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include "config.h"

--- a/gusb/gusb-json-common.h
+++ b/gusb/gusb-json-common.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2023 Collabora Ltd.
  *    @author Frédéric Danis <frederic.danis@collabora.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-private.h
+++ b/gusb/gusb-private.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-self-test.c
+++ b/gusb/gusb-self-test.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include "config.h"

--- a/gusb/gusb-source.c
+++ b/gusb/gusb-source.c
@@ -3,7 +3,7 @@
  * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb-source.h
+++ b/gusb/gusb-source.h
@@ -3,7 +3,7 @@
  * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-umockdev-test.c
+++ b/gusb/gusb-umockdev-test.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2022 Benjamin Berg <bberg@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include <glib.h>

--- a/gusb/gusb-util.c
+++ b/gusb/gusb-util.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include "config.h"

--- a/gusb/gusb-util.h
+++ b/gusb/gusb-util.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Hans de Goede <hdegoede@redhat.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/gusb/gusb-version.c
+++ b/gusb/gusb-version.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2018 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include "config.h"

--- a/gusb/gusb-version.h.in
+++ b/gusb/gusb-version.h.in
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 /**

--- a/gusb/gusb.h
+++ b/gusb/gusb.h
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2010 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #pragma once

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('libgusb', 'c',
   version : '0.4.9',
-  license : 'LGPL-2.1+',
+  license : 'LGPL-2.1-or-later',
   meson_version : '>=0.56.0',
   default_options : ['c_std=c99']
 )

--- a/tools/gusb-main.c
+++ b/tools/gusb-main.c
@@ -2,7 +2,7 @@
  *
  * Copyright (C) 2011 Richard Hughes <richard@hughsie.com>
  *
- * SPDX-License-Identifier: LGPL-2.1+
+ * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
 #include "config.h"


### PR DESCRIPTION
[LGPL-2.1+](https://spdx.org/licenses/LGPL-2.1+.html) is a deprecated SPDX license ID, replacing it with [LGPL-2.1-or-later](https://spdx.org/licenses/LGPL-2.1-or-later.html).

---

relates to https://github.com/Homebrew/homebrew-core/pull/169951