### PR TITLE
Convert version parsing from pkg_resources to packaging

### DIFF
--- a/contrib/generate-version-script.py
+++ b/contrib/generate-version-script.py
@@ -8,7 +8,7 @@
 import sys
 import xml.etree.ElementTree as ET
 
-from pkg_resources import parse_version
+from packaging.version import parse
 
 XMLNS = '{http://www.gtk.org/introspection/core/1.0}'
 XMLNS_C = '{http://www.gtk.org/introspection/c/1.0}'
@@ -55,14 +55,14 @@ class LdVersionScript:
         for node in cls.findall(XMLNS + 'method'):
             version_tmp = self._add_node(node)
             if version_tmp:
-                if not version_lowest or parse_version(version_tmp) < parse_version(version_lowest):
+                if not version_lowest or parse(version_tmp) < parse(version_lowest):
                     version_lowest = version_tmp
 
         # add the constructor
         for node in cls.findall(XMLNS + 'constructor'):
             version_tmp = self._add_node(node)
             if version_tmp:
-                if not version_lowest or parse_version(version_tmp) < parse_version(version_lowest):
+                if not version_lowest or parse(version_tmp) < parse(version_lowest):
                     version_lowest = version_tmp
 
         if '{http://www.gtk.org/introspection/glib/1.0}get-type' not in cls.attrib:
@@ -94,7 +94,7 @@ class LdVersionScript:
         # output the version data to a file
         verout = '# generated automatically, do not edit!\n'
         oldversion = None
-        for version in sorted(versions, key=parse_version):
+        for version in sorted(versions, key=parse):
             symbols = sorted(self.releases[version])
             verout += '\n%s_%s {\n' % (self.library_name, version)
             verout += '  global:\n'


### PR DESCRIPTION
`pkg_resources` is deprecated; this particular functionality now lives in `packaging`

Need to update CI since `packaging` is not part of the default system package set? Also maybe enforce `packaging`'s presence in `meson.build`